### PR TITLE
Update outcome to remove form LS01

### DIFF
--- a/lib/smart_answer_flows/report-a-lost-or-stolen-passport/outcomes/complete_LS01_form.govspeak.erb
+++ b/lib/smart_answer_flows/report-a-lost-or-stolen-passport/outcomes/complete_LS01_form.govspeak.erb
@@ -1,28 +1,16 @@
 <% content_for :body do %>
-  You must report your lost or stolen passport to Her Majesty's Passport Office.
+If your passport has been lost or stolen, cancel it by [reporting it online](https://www.loststolenpassport.service.gov.uk/report/passport-holder) as soon as possible. 
 
-  To report your lost passport you can do any of:
+^You’ll need a UK mobile number. If you don’t have one, you can use an email address and a landline number.
 
-  - [download a copy of form LS01](/government/publications/report-a-lost-or-stolen-passport-form-ls01) and post the completed form to Her Majesty's Passport Office - the address is on the form
-  - get a copy of form LS01 from a Post Office that offers the [Check and Send service](/how-the-post-office-check-and-send-service-works)
-  - use the new [online service](https://www.loststolenpassport.service.gov.uk/report) - this service is [in beta](/help/beta)
+##Help cancelling your passport
 
+[Contact the Passport Adviceline](https://www.gov.uk/passport-advice-line) if you need help.
 
-  ^You’ll need a daytime telephone number and either an email address or UK mobile number to use the online service.^
+##Replace your passport
 
+You'll also need to apply for a replacement passport if you want one. Follow [guidance on replacing your passport](https://www.gov.uk/renew-adult-passport/overview).
 
-  %Your signature will be compared to the signature on the original passport application form. If the original application was made by someone else, you’ll also need to send a signed letter from that person confirming that the passport has been lost or stolen. This is to help prevent child abduction.%
-
-  You can use the [online enquiry form](https://eforms.homeoffice.gov.uk/outreach/Passport_Enquiries.ofml) to contact Her Majesty’s Passport Office for general advice.
-
-  ##Replacing your passport
-
-  You can apply for a replacement at the same time if you’re a British national and in the UK.
-
-  Follow the same process as [renewing a passport](/renew-adult-passport) but you must send a completed form LS01 with your application (if you haven’t already reported it as lost)
-
-  ^Use the [online enquiry form](https://eforms.homeoffice.gov.uk/outreach/Passport_Enquiries.ofml) to contact Her Majesty’s Passport Office for general advice.
-
-  % You can’t use the [1-day Premium service](/get-a-passport-urgently) if you’re replacing a lost passport. %
+%You can’t use the [1-day Premium service](https://www.gov.uk/get-a-passport-urgently) if you’re replacing a lost passport.%
 
 <% end %>


### PR DESCRIPTION
Removed LS01 form because from 1 May users have to use the service.

https://trello.com/c/eqKPSyLq/739-2-may-change-to-lost-or-stolen-passport-tool-content-change-request

https://govuk.zendesk.com/agent/#/tickets/1969582